### PR TITLE
Rc as rcref

### DIFF
--- a/src/rc.rs
+++ b/src/rc.rs
@@ -652,9 +652,11 @@ impl<T: ?Sized, const NUM: usize, const DEN: usize> StaticRc<T, NUM, DEN> {
         //      -  `this.pointer` is a valid aligned pointer into a valid value of `T`.
         //  -   The result is only usable for lifetime `'a`, and for the duration
         //      of the lifetime `'a` `this` is frozen.
-        //  -   `this` has NUM/DEN of the ownership. So It can lend NUM/DEN
+        //  -   `this` has NUM/DEN of the ownership. So it can lend NUM/DEN
         //      of the right to mutate the value. Therefore, this is semantically sound
         //      according to the general principle of this library.
+        //
+        //  This is safe for generally the same reason `StaticRcRef::reborrow` is safe.
         //
         //  `StaticRcRef::from_raw` has to have a comment documenting
         //  internally that such a use is allowed.

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -641,7 +641,25 @@ impl<T: ?Sized, const NUM: usize, const DEN: usize> StaticRc<T, NUM, DEN> {
         array
     }
 
-    /// Stub TODO
+    /// Converts an instance into a [`StaticRcRef`](super::StaticRcRef).
+    /// The current instance is frozen for the duration the result can be used.
+    /// ```rust
+    /// use static_rc::StaticRc;
+    /// use static_rc::StaticRcRef;
+    /// let rc: StaticRc<_, 2, 2> = StaticRc::new(5);
+    /// let (mut rc1, mut rc2) = StaticRc::split::<1, 1>(rc);
+    /// {
+    ///     // Modify without moving `rc1`, `rc2`.
+    ///     let rcref1 = StaticRc::as_rcref(&mut rc1);
+    ///     let rcref2 = StaticRc::as_rcref(&mut rc2);
+    ///     let mut rcref_owning: StaticRcRef<_, 2, 2> = StaticRcRef::join(rcref1, rcref2);
+    ///     *rcref_owning = 9;
+    ///     // Refs not used anymore, original rcs can be used again
+    /// }
+    /// let rc: StaticRc<_, 2, 2> = StaticRc::join(rc1, rc2);
+    /// assert_eq!(*rc, 9);
+    /// assert_eq!(*StaticRc::into_box(rc), 9);
+    /// ```
     #[inline(always)]
     pub fn as_rcref<'a>(this: &'a mut Self) -> super::StaticRcRef<'a, T, NUM, DEN> {
         //  Safety:

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -640,6 +640,29 @@ impl<T: ?Sized, const NUM: usize, const DEN: usize> StaticRc<T, NUM, DEN> {
 
         array
     }
+
+    /// Stub TODO
+    #[inline(always)]
+    pub fn as_rcref<'a>(this: &'a mut Self) -> super::StaticRcRef<'a, T, NUM, DEN> {
+        //  Safety:
+        //  -   The public documentation says that `StaticRcRef::from_raw`
+        //      can only be called on pointers returned from `StaticRcRef::into_raw`.
+        //      which this isn't.
+        //  -   However, internally the library knows that `rc` and `rcref` have the same invariants:
+        //      -  `this.pointer` is a valid aligned pointer into a valid value of `T`.
+        //  -   The result is only usable for lifetime `'a`, and for the duration
+        //      of the lifetime `'a` `this` is frozen.
+        //  -   `this` has NUM/DEN of the ownership. So It can lend NUM/DEN
+        //      of the right to mutate the value. Therefore, this is semantically sound
+        //      according to the general principle of this library.
+        //
+        //  `StaticRcRef::from_raw` has to have a comment documenting
+        //  internally that such a use is allowed.
+        let ptr = this.pointer;
+        unsafe {
+            super::StaticRcRef::from_raw(ptr)
+        }
+    } 
 }
 
 impl<const NUM: usize, const DEN: usize> StaticRc<dyn any::Any, NUM, DEN> {

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1025,6 +1025,31 @@ unsafe impl<T: ?Sized + marker::Send, const NUM: usize, const DEN: usize> marker
 unsafe impl<T: ?Sized + marker::Sync, const NUM: usize, const DEN: usize> marker::Sync for StaticRc<T, NUM, DEN> {}
 
 #[doc(hidden)]
+pub mod compile_tests {
+
+/// ```compile_fail,E0505
+/// let mut a = String::from("foo");
+/// let mut rc = static_rc::StaticRc::<_,1,1>::new(a);
+/// 
+/// let mut reborrow = static_rc::StaticRc::as_rcref(&mut rc);
+/// std::mem::drop(rc);
+/// assert_eq!(*reborrow, "foo"); // This should fail to compile.
+/// ```
+pub fn rc_reborrow_and_move() {}
+
+/// ```compile_fail,E0502
+/// let mut a = String::from("foo");
+/// let mut rc = static_rc::StaticRc::<_,1,1>::new(a);
+/// 
+/// let mut reborrow = static_rc::StaticRc::as_rcref(&mut rc);
+/// assert_eq!(*rc, "foo");
+/// assert_eq!(*reborrow, "foo"); // This should fail to compile.
+/// ```
+pub fn rc_reborrow_and_use() {}
+
+} // mod compile_tests
+
+#[doc(hidden)]
 #[cfg(feature = "compile-time-ratio")]
 pub mod compile_ratio_tests {
 

--- a/src/rcref.rs
+++ b/src/rcref.rs
@@ -207,6 +207,8 @@ impl<'a, T: ?Sized, const NUM: usize, const DEN: usize> StaticRcRef<'a, T, NUM, 
     ///     for the restrictions applying to transmuting references.
     /// -   If `N / D` is different from `NUM / DEN`, then specific restrictions apply. The user is responsible for
     ///     ensuring proper management of the ratio of shares, and ultimately that the value is not dropped twice.
+    //  Internal comment: Internally, calling `from_raw` in the specific case of `StaticRc::as_rcref`
+    //  is allowed. This isn't allowed as an external user of the library.
     #[inline(always)]
     pub unsafe fn from_raw(pointer: NonNull<T>) -> Self
     where

--- a/src/rcref.rs
+++ b/src/rcref.rs
@@ -826,6 +826,26 @@ pub mod compile_tests {
 /// ```
 pub fn rcref_prevent_use_after_free() {}
 
+/// ```compile_fail,E0505
+/// let mut a = String::from("foo");
+/// let mut rc = static_rc::StaticRcRef::<'_, _,1,1>::new(&mut a);
+/// 
+/// let mut reborrow = static_rc::StaticRcRef::reborrow(&mut rc);
+/// std::mem::drop(rc);
+/// assert_eq!(*reborrow, "foo"); // This should fail to compile.
+/// ```
+pub fn rcref_reborrow_and_move() {}
+
+/// ```compile_fail,E0502
+/// let mut a = String::from("foo");
+/// let mut rc = static_rc::StaticRcRef::<'_, _,1,1>::new(&mut a);
+/// 
+/// let mut reborrow = static_rc::StaticRcRef::reborrow(&mut rc);
+/// assert_eq!(*rc, "foo");
+/// assert_eq!(*reborrow, "foo"); // This should fail to compile.
+/// ```
+pub fn rcref_reborrow_and_use() {}
+
 } // mod compile_tests
 
 #[doc(hidden)]

--- a/src/rcref.rs
+++ b/src/rcref.rs
@@ -274,6 +274,44 @@ impl<'a, T: ?Sized, const NUM: usize, const DEN: usize> StaticRcRef<'a, T, NUM, 
         StaticRcRef { pointer: this.pointer, _marker: PhantomData }
     }
 
+    /// Reborrows into another [`StaticRcRef`].
+    /// 
+    /// The current instance is mutably borrowed for the duration the result can be used.
+    /// 
+    /// #   Example
+    /// 
+    /// ```rust
+    /// use static_rc::StaticRcRef;
+    /// let mut x = 5;
+    /// let rc_full: StaticRcRef<i32, 2, 2> = StaticRcRef::new(&mut x);
+    /// let (mut rc1, mut rc2) = StaticRcRef::split::<1, 1>(rc_full);
+    /// {
+    ///     // Modify without moving `rc1`, `rc2`.
+    ///     let rc_borrow1 = StaticRcRef::reborrow(&mut rc1);
+    ///     let rc_borrow2 = StaticRcRef::reborrow(&mut rc2);
+    ///     let mut rcref_full: StaticRcRef<_, 2, 2> = StaticRcRef::join(rc_borrow1, rc_borrow2);
+    ///     *rcref_full = 9;
+    ///     // Reborrow ends, can use the original refs again
+    /// }
+    /// let rc_full: StaticRcRef<_, 2, 2> = StaticRcRef::join(rc1, rc2);
+    /// assert_eq!(*rc_full, 9);
+    /// assert_eq!(x, 9);
+    /// ```
+    #[inline(always)]
+    pub fn reborrow<'reborrow>(this: &'reborrow mut Self) -> StaticRcRef<'reborrow, T, NUM, DEN> {
+        //  Safety (even though this doesn't use the `unsafe` keyword):
+        //  -  `this.pointer` is a valid aligned pointer into a valid value of `T`.
+        //  -   The result is only usable for lifetime `'a`, and for the duration
+        //      of the lifetime `'a` `this` is mutably borrowed.
+        //  -   `this` has NUM/DEN of the right to mutate the value. So it can lend NUM/DEN
+        //      of the right to mutate the value. Therefore, this is semantically sound
+        //      according to the general principle of this library.
+        StaticRcRef {
+            pointer: this.pointer,
+            _marker: PhantomData::default(),
+        }
+    }
+
     /// Splits the current instance into two instances with the specified NUMerators.
     ///
     /// #   Panics
@@ -537,39 +575,7 @@ impl<'a, T: ?Sized, const NUM: usize, const DEN: usize> StaticRcRef<'a, T, NUM, 
         Self { pointer: array[0].pointer, _marker: PhantomData, }
     }
 
-    /// Reborrows into another [`StaticRcRef`].
-    /// The current instance is frozen for the duration the result can be used.
-    /// ```rust
-    /// use static_rc::StaticRcRef;
-    /// let mut x = 5;
-    /// let rc_full: StaticRcRef<i32, 2, 2> = StaticRcRef::new(&mut x);
-    /// let (mut rc1, mut rc2) = StaticRcRef::split::<1, 1>(rc_full);
-    /// {
-    ///     // Modify without moving `rc1`, `rc2`.
-    ///     let rc_borrow1 = StaticRcRef::reborrow(&mut rc1);
-    ///     let rc_borrow2 = StaticRcRef::reborrow(&mut rc2);
-    ///     let mut rcref_full: StaticRcRef<_, 2, 2> = StaticRcRef::join(rc_borrow1, rc_borrow2);
-    ///     *rcref_full = 9;
-    ///     // Reborrow ends, can use the original refs again
-    /// }
-    /// let rc_full: StaticRcRef<_, 2, 2> = StaticRcRef::join(rc1, rc2);
-    /// assert_eq!(*rc_full, 9);
-    /// assert_eq!(x, 9);
-    /// ```
-    #[inline(always)]
-    pub fn reborrow<'reborrow>(this: &'reborrow mut Self) -> StaticRcRef<'reborrow, T, NUM, DEN> {
-        //  Safety (even though this doesn't use the `unsafe` keyword):
-        //  -  `this.pointer` is a valid aligned pointer into a valid value of `T`.
-        //  -   The result is only usable for lifetime `'a`, and for the duration
-        //      of the lifetime `'a` `this` is frozen.
-        //  -   `this` has NUM/DEN of the right to mutate the value. So it can lend NUM/DEN
-        //      of the right to mutate the value. Therefore, this is semantically sound
-        //      according to the general principle of this library.
-        StaticRcRef {
-            pointer: this.pointer,
-            _marker: PhantomData::default(),
-        }
-    }
+    
 }
 
 impl<'a, const NUM: usize, const DEN: usize> StaticRcRef<'a, dyn any::Any, NUM, DEN> {

--- a/src/rcref.rs
+++ b/src/rcref.rs
@@ -537,7 +537,25 @@ impl<'a, T: ?Sized, const NUM: usize, const DEN: usize> StaticRcRef<'a, T, NUM, 
         Self { pointer: array[0].pointer, _marker: PhantomData, }
     }
 
-    /// Stub TODO
+    /// Reborrows into another [`StaticRcRef`].
+    /// The current instance is frozen for the duration the result can be used.
+    /// ```rust
+    /// use static_rc::StaticRcRef;
+    /// let mut x = 5;
+    /// let rc_full: StaticRcRef<i32, 2, 2> = StaticRcRef::new(&mut x);
+    /// let (mut rc1, mut rc2) = StaticRcRef::split::<1, 1>(rc_full);
+    /// {
+    ///     // Modify without moving `rc1`, `rc2`.
+    ///     let rc_borrow1 = StaticRcRef::reborrow(&mut rc1);
+    ///     let rc_borrow2 = StaticRcRef::reborrow(&mut rc2);
+    ///     let mut rcref_full: StaticRcRef<_, 2, 2> = StaticRcRef::join(rc_borrow1, rc_borrow2);
+    ///     *rcref_full = 9;
+    ///     // Reborrow ends, can use the original refs again
+    /// }
+    /// let rc_full: StaticRcRef<_, 2, 2> = StaticRcRef::join(rc1, rc2);
+    /// assert_eq!(*rc_full, 9);
+    /// assert_eq!(x, 9);
+    /// ```
     #[inline(always)]
     pub fn reborrow<'reborrow>(this: &'reborrow mut Self) -> StaticRcRef<'reborrow, T, NUM, DEN> {
         //  Safety (even though this doesn't use the `unsafe` keyword):

--- a/src/rcref.rs
+++ b/src/rcref.rs
@@ -536,6 +536,22 @@ impl<'a, T: ?Sized, const NUM: usize, const DEN: usize> StaticRcRef<'a, T, NUM, 
 
         Self { pointer: array[0].pointer, _marker: PhantomData, }
     }
+
+    /// Stub TODO
+    #[inline(always)]
+    pub fn reborrow<'reborrow>(this: &'reborrow mut Self) -> StaticRcRef<'reborrow, T, NUM, DEN> {
+        //  Safety (even though this doesn't use the `unsafe` keyword):
+        //  -  `this.pointer` is a valid aligned pointer into a valid value of `T`.
+        //  -   The result is only usable for lifetime `'a`, and for the duration
+        //      of the lifetime `'a` `this` is frozen.
+        //  -   `this` has NUM/DEN of the right to mutate the value. So it can lend NUM/DEN
+        //      of the right to mutate the value. Therefore, this is semantically sound
+        //      according to the general principle of this library.
+        StaticRcRef {
+            pointer: this.pointer,
+            _marker: PhantomData::default(),
+        }
+    }
 }
 
 impl<'a, const NUM: usize, const DEN: usize> StaticRcRef<'a, dyn any::Any, NUM, DEN> {


### PR DESCRIPTION
This pull request adds a feature allowing `StaticRc` and `StaticRcRef` to be frozen in order to temporarily create a new `StaticRcRef` that has the same "ratio" of a `&mut T`. Since the original is frozen, the overall ownership of the `&mut T` is still preserved. This can allow changing a value through separate `StaticRc`s stored in different parts while not having to constantly move them around.

Honestly I'm not sure how useful it is, because I haven't had time to check yet, but I have a feeling this can be used to improve some of the data structures that can currently be implemented using `static_rc`.

I'm pretty sure this is sound, but this does "allow" more than 1 overall ownership at a single time. But it isn't supposed to matter since only 1 overall ownership is usable at any single time. Perhaps you would like to put this under an experimental feature for now?

The pull request is currently missing tests, except the two doctests. 