### PR TITLE
fix: update nightly features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ alloc = []
 #   Enables `lift`, an experimental feature to allow tying the knot.
 experimental-lift = []
 
-#   Enables `Stream` on `StaticRc`.
-#   This currently requires nightly, and specifically the `async_stream` feature.
-nightly-async-stream = []
+#   Enables `AsyncIterator` on `StaticRc`.
+#   This currently requires nightly, and specifically the `async_iterator` feature.
+nightly-async-iterator = []
 
 #   Enables `CoerceUnsized` on `StaticRc`.
 #   This currently requires nightly, and specifically the `coerce_unsized` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@
 
 //  Nightly features
 #![cfg_attr(feature = "compile-time-ratio", allow(incomplete_features))]
-#![cfg_attr(feature = "compile-time-ratio", feature(const_generics, const_evaluatable_checked))]
-#![cfg_attr(feature = "nightly-async-stream", feature(async_stream))]
+#![cfg_attr(feature = "compile-time-ratio", feature(generic_const_exprs))]
+#![cfg_attr(feature = "nightly-async-iterator", feature(async_iterator))]
 #![cfg_attr(feature = "nightly-coerce-unsized", feature(coerce_unsized))]
 #![cfg_attr(feature = "nightly-dispatch-from-dyn", feature(dispatch_from_dyn))]
 #![cfg_attr(any(feature = "nightly-dispatch-from-dyn", feature = "nightly-coerce-unsized"), feature(unsize))]

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -19,8 +19,8 @@ use core::{
 
 use alloc::boxed::Box;
 
-#[cfg(feature = "nightly-async-stream")]
-use core::stream;
+#[cfg(feature = "nightly-async-iterator")]
+use core::async_iter;
 
 #[cfg(feature = "nightly-coerce-unsized")]
 use core::ops::CoerceUnsized;
@@ -347,7 +347,10 @@ impl<T: ?Sized, const NUM: usize, const DEN: usize> StaticRc<T, NUM, DEN> {
     /// assert_eq!(*StaticRc::into_box(rc), 9);
     /// ```
     #[inline(always)]
-    pub fn as_rcref<'a>(this: &'a mut Self) -> super::StaticRcRef<'a, T, NUM, DEN> {
+    pub fn as_rcref<'a>(this: &'a mut Self) -> super::StaticRcRef<'a, T, NUM, DEN> 
+    where
+        AssertLeType!(1, NUM): Sized,
+    {
         //  Safety:
         //  -   The public documentation says that `StaticRcRef::from_raw`
         //      can only be called on pointers returned from `StaticRcRef::into_raw`.
@@ -1007,8 +1010,8 @@ impl<T: ?Sized, const NUM: usize, const DEN: usize> fmt::Pointer for StaticRc<T,
     }
 }
 
-#[cfg(feature = "nightly-async-stream")]
-impl<S: ?Sized + stream::Stream + marker::Unpin, const N: usize> stream::Stream for StaticRc<S, N, N> {
+#[cfg(feature = "nightly-async-iterator")]
+impl<S: ?Sized + async_iter::AsyncIterator + marker::Unpin, const N: usize> async_iter::AsyncIterator for StaticRc<S, N, N> {
     type Item = S::Item;
 
     fn poll_next(mut self: pin::Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Option<Self::Item>> {

--- a/src/rcref.rs
+++ b/src/rcref.rs
@@ -17,8 +17,8 @@ use core::{
     task,
 };
 
-#[cfg(feature = "nightly-async-stream")]
-use core::stream;
+#[cfg(feature = "nightly-async-iterator")]
+use core::async_iter;
 
 #[cfg(feature = "nightly-coerce-unsized")]
 use core::ops::CoerceUnsized;
@@ -767,8 +767,8 @@ impl<'a, T: ?Sized, const NUM: usize, const DEN: usize> fmt::Pointer for StaticR
     }
 }
 
-#[cfg(feature = "nightly-async-stream")]
-impl<'a, S: ?Sized + stream::Stream + marker::Unpin, const N: usize> stream::Stream for StaticRcRef<'a, S, N, N> {
+#[cfg(feature = "nightly-async-iterator")]
+impl<'a, S: ?Sized + async_iter::AsyncIterator + marker::Unpin, const N: usize> async_iter::AsyncIterator for StaticRcRef<'a, S, N, N> {
     type Item = S::Item;
 
     fn poll_next(mut self: pin::Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Option<Self::Item>> {


### PR DESCRIPTION
This PR updates two nightly-only features to be compatible with the latest rust versions:
- `nightly-async-stream` - `stream` got renamed to `async_iter` in 1.60. Renamed the crate feature accordingly
- `compile-time-ratio` - With the const generics MVP landing in 1.51 the feature gate names have changed. Updated the acordingly and added a constraint on `StaticRc::as_rcref` that was causing compilation to fail.